### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ng2-charts": "^1.6.0",
     "ngx-bootstrap": "^3.2.0",
     "ngx-perfect-scrollbar": "^7.2.1",
-    "npm": "^6.9.0",
     "rxjs": "^6.4.0",
     "rxjs-compat": "^6.4.0",
     "simple-line-icons": "^2.4.1",


### PR DESCRIPTION

Hello manopriya-jagadeesan!

It seems like you have npm as one of your (dev-) dependency in 580414-hackathon-frontend.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
